### PR TITLE
Added reset prop with animation and duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@
     <b>titleColor</b>: PropTypes.string,
     <b>titleFontSize</b>: PropTypes.number,
     <b>width</b>: PropTypes.number,
+    <b>shouldResetAfterSuccess</b>: PropTypes.bool,
+    <b>resetAfterSuccessDuration</b>: PropTypes.number,
 </pre>
 <hr>
 <h2 style="color:darkgreen;">Code for above screenshots</h2>

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
     <b>titleFontSize</b>: PropTypes.number,
     <b>width</b>: PropTypes.number,
     <b>shouldResetAfterSuccess</b>: PropTypes.bool,
-    <b>resetAfterSuccessDuration</b>: PropTypes.number,
+    <b>resetAfterSuccessAnimDuration</b>: PropTypes.number,
 </pre>
 <hr>
 <h2 style="color:darkgreen;">Code for above screenshots</h2>

--- a/src/components/SwipeButton/index.js
+++ b/src/components/SwipeButton/index.js
@@ -109,6 +109,8 @@ class SwipeButton extends React.Component {
       titleColor,
       titleFontSize,
       width,
+      shouldResetAfterSuccess,
+      resetAfterSuccessDuration,
     } = this.props;
     const {screenReaderEnabled} = this.state;
 
@@ -158,6 +160,8 @@ class SwipeButton extends React.Component {
             thumbIconComponent={thumbIconComponent}
             thumbIconImageSource={thumbIconImageSource}
             title={title}
+            shouldResetAfterSuccess={shouldResetAfterSuccess}
+            resetAfterSuccessDuration={resetAfterSuccessDuration}
           />
         )}
       </View>
@@ -214,6 +218,8 @@ SwipeButton.propTypes = {
   titleColor: PropTypes.string,
   titleFontSize: PropTypes.number,
   width: PropTypes.number,
+  shouldResetAfterSuccess: PropTypes.bool,
+  resetAfterSuccessDuration: PropTypes.number,
 };
 
 export default SwipeButton;

--- a/src/components/SwipeButton/index.js
+++ b/src/components/SwipeButton/index.js
@@ -110,7 +110,7 @@ class SwipeButton extends React.Component {
       titleFontSize,
       width,
       shouldResetAfterSuccess,
-      resetAfterSuccessDuration,
+      resetAfterSuccessAnimDuration,
     } = this.props;
     const {screenReaderEnabled} = this.state;
 
@@ -161,7 +161,7 @@ class SwipeButton extends React.Component {
             thumbIconImageSource={thumbIconImageSource}
             title={title}
             shouldResetAfterSuccess={shouldResetAfterSuccess}
-            resetAfterSuccessDuration={resetAfterSuccessDuration}
+            resetAfterSuccessAnimDuration={resetAfterSuccessAnimDuration}
           />
         )}
       </View>
@@ -219,7 +219,7 @@ SwipeButton.propTypes = {
   titleFontSize: PropTypes.number,
   width: PropTypes.number,
   shouldResetAfterSuccess: PropTypes.bool,
-  resetAfterSuccessDuration: PropTypes.number,
+  resetAfterSuccessAnimDuration: PropTypes.number,
 };
 
 export default SwipeButton;

--- a/src/components/SwipeThumb/index.js
+++ b/src/components/SwipeThumb/index.js
@@ -149,7 +149,7 @@ class SwipeThumb extends React.Component {
       if (this.props.shouldResetAfterSuccess)
         Animated.timing(this.state.animatedWidth, {
           toValue: this.defaultContainerWidth,
-          duration: this.props.resetAfterSuccessDuration || 200,
+          duration: this.props.resetAfterSuccessAnimDuration || 200,
         }).start(() => this.reset());
     });
   }
@@ -272,7 +272,7 @@ SwipeThumb.propTypes = {
   ]),
   title: PropTypes.string,
   shouldResetAfterSuccess: PropTypes.bool,
-  resetAfterSuccessDuration: PropTypes.number,
+  resetAfterSuccessAnimDuration: PropTypes.number,
 };
 
 export default SwipeThumb;

--- a/src/components/SwipeThumb/index.js
+++ b/src/components/SwipeThumb/index.js
@@ -144,12 +144,19 @@ class SwipeThumb extends React.Component {
       if (this.props.onSwipeSuccess) {
         this.props.onSwipeSuccess();
       }
-      // this.reset(); // Enable this line to reset the thumb after successful swipe
+
+      //Animate back to initial position
+      if (this.props.shouldResetAfterSuccess)
+        Animated.timing(this.state.animatedWidth, {
+          toValue: this.defaultContainerWidth,
+          duration: this.props.resetAfterSuccessDuration || 200,
+        }).start(() => this.reset());
     });
   }
 
   reset() {
     this.state.animatedWidth.setValue(this.defaultContainerWidth);
+
     if (this.state.backgroundColor !== TRANSPARENT_COLOR) {
       this.setState({
         backgroundColor: TRANSPARENT_COLOR,
@@ -264,6 +271,8 @@ SwipeThumb.propTypes = {
     PropTypes.number,
   ]),
   title: PropTypes.string,
+  shouldResetAfterSuccess: PropTypes.bool,
+  resetAfterSuccessDuration: PropTypes.number,
 };
 
 export default SwipeThumb;


### PR DESCRIPTION
Fixes #7 

* Added two new props, `shouldResetAfterSuccess: boolean`, `resetAfterSuccessDuration: number` that controls the SwipeButton resetting.

* Added an animation before the `reset()` to make the button go back to its initial position.

* Updated the `README.md` with the new props.