### PR TITLE
Renamed 'fetch' AccessibilityInfo method to 'isScreenReaderEnabled'.

### DIFF
--- a/src/components/SwipeButton/index.js
+++ b/src/components/SwipeButton/index.js
@@ -41,7 +41,7 @@ class SwipeButton extends React.Component {
       'change',
       this.handleScreenReaderToggled,
     );
-    AccessibilityInfo.fetch().then(isEnabled => {
+    AccessibilityInfo.isScreenReaderEnabled().then(isEnabled => {
       if (this.isUnmounting) {
         return;
       }


### PR DESCRIPTION
I'm not sure should we provide any backward compatibility for RN < 0.60.