### PR TITLE
Apply railStyles last to override container styles (eg. borderRadius)

### DIFF
--- a/src/components/SwipeThumb/index.js
+++ b/src/components/SwipeThumb/index.js
@@ -207,8 +207,8 @@ const SwipeThumb = props => {
     backgroundColor,
     borderColor,
     width: animatedWidth,
-    ...railStyles,
     ...(enableReverseSwipe ? styles.containerRTL : styles.container),
+    ...railStyles,
   };
 
   return (


### PR DESCRIPTION
The aim of this PR is to make the `railFill` styles match the `rail`'s style

## Before
![image](https://user-images.githubusercontent.com/38657323/94444869-10ebff00-01a7-11eb-9c5e-573544e07cea.png)

## After
![image](https://user-images.githubusercontent.com/38657323/94445004-3d078000-01a7-11eb-8d9f-06863cf65034.png)
