### PR TITLE
:hammer: Fix thumbIconComponent types error in typescript

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -23,7 +23,7 @@ interface Props {
     swipeSuccessThreshold?: number; // Ex: 70. Swipping 70% will be considered as successful swipe
     thumbIconBackgroundColor?: string;
     thumbIconBorderColor?: string;
-    thumbIconComponent?: ReactElement;
+    thumbIconComponent?: () => ReactElement;
     thumbIconImageSource?: string | number;
     thumbIconStyles?: StyleProp<ViewStyle>;
     thumbIconWidth?: number;


### PR DESCRIPTION
Related Issue:
- https://github.com/UdaySravanK/RNSwipeButton/issues/105

**Note:**
This PR is to fix the issue related typing incorrect for thumbIconComponent.

**Possible Workaround?**
Possible workaround only by disabled eslint for typescript