### PR TITLE
#136 Fixing the deprecated defaultProps warning.

### DIFF
--- a/src/components/SwipeButton/index.js
+++ b/src/components/SwipeButton/index.js
@@ -23,7 +23,40 @@ import {
   TITLE_COLOR,
 } from "../../constants";
 
-const SwipeButton = (props) => {
+const SwipeButton = ({
+  containerStyles = {},
+  disabled = false,
+  disabledRailBackgroundColor = DISABLED_RAIL_BACKGROUND_COLOR,
+  disabledThumbIconBackgroundColor = DISABLED_THUMB_ICON_BACKGROUND_COLOR,
+  disabledThumbIconBorderColor = DISABLED_THUMB_ICON_BORDER_COLOR,
+  disableResetOnTap = false,
+  enableReverseSwipe,
+  forceReset,
+  height = 50,
+  onSwipeFail,
+  onSwipeStart,
+  onSwipeSuccess,
+  railBackgroundColor = RAIL_BACKGROUND_COLOR,
+  railBorderColor = RAIL_BORDER_COLOR,
+  railFillBackgroundColor = RAIL_FILL_BACKGROUND_COLOR,
+  railFillBorderColor = RAIL_FILL_BORDER_COLOR,
+  railStyles,
+  resetAfterSuccessAnimDelay,
+  shouldResetAfterSuccess,
+  swipeSuccessThreshold = SWIPE_SUCCESS_THRESHOLD,
+  thumbIconBackgroundColor = THUMB_ICON_BACKGROUND_COLOR,
+  thumbIconBorderColor = THUMB_ICON_BORDER_COLOR,
+  thumbIconComponent,
+  thumbIconImageSource,
+  thumbIconStyles = {},
+  thumbIconWidth,
+  title = "Swipe to submit",
+  titleColor = TITLE_COLOR,
+  titleFontSize = 20,
+  titleMaxFontScale,
+  titleStyles = {},
+  width,
+}) => {
   const [layoutWidth, setLayoutWidth] = useState(0);
   const [screenReaderEnabled, setScreenReaderEnabled] = useState(false);
   const [isUnmounting, setIsUnmounting] = useState(false);
@@ -66,41 +99,6 @@ const SwipeButton = (props) => {
     };
   }, [isUnmounting, screenReaderEnabled]);
 
-  const {
-    containerStyles,
-    disabled,
-    disabledRailBackgroundColor,
-    disabledThumbIconBackgroundColor,
-    disabledThumbIconBorderColor,
-    disableResetOnTap,
-    enableReverseSwipe,
-    forceReset,
-    height,
-    onSwipeFail,
-    onSwipeStart,
-    onSwipeSuccess,
-    railBackgroundColor,
-    railBorderColor,
-    railFillBackgroundColor,
-    railFillBorderColor,
-    railStyles,
-    resetAfterSuccessAnimDelay,
-    resetAfterSuccessAnimDuration,
-    shouldResetAfterSuccess,
-    swipeSuccessThreshold,
-    thumbIconBackgroundColor,
-    thumbIconBorderColor,
-    thumbIconComponent,
-    thumbIconImageSource,
-    thumbIconStyles,
-    thumbIconWidth,
-    title,
-    titleColor,
-    titleFontSize,
-    titleMaxFontScale,
-    titleStyles,
-    width,
-  } = props;
   return (
     <View
       style={[
@@ -150,7 +148,6 @@ const SwipeButton = (props) => {
           railFillBorderColor={railFillBorderColor}
           railStyles={railStyles}
           resetAfterSuccessAnimDelay={resetAfterSuccessAnimDelay}
-          resetAfterSuccessAnimDuration={resetAfterSuccessAnimDuration}
           screenReaderEnabled={screenReaderEnabled}
           shouldResetAfterSuccess={shouldResetAfterSuccess}
           swipeSuccessThreshold={swipeSuccessThreshold}
@@ -166,28 +163,6 @@ const SwipeButton = (props) => {
       )}
     </View>
   );
-};
-
-SwipeButton.defaultProps = {
-  containerStyles: {},
-  disabled: false,
-  disabledRailBackgroundColor: DISABLED_RAIL_BACKGROUND_COLOR,
-  disabledThumbIconBackgroundColor: DISABLED_THUMB_ICON_BACKGROUND_COLOR,
-  disabledThumbIconBorderColor: DISABLED_THUMB_ICON_BORDER_COLOR,
-  disableResetOnTap: false,
-  height: 50,
-  railBackgroundColor: RAIL_BACKGROUND_COLOR,
-  railBorderColor: RAIL_BORDER_COLOR,
-  railFillBackgroundColor: RAIL_FILL_BACKGROUND_COLOR,
-  railFillBorderColor: RAIL_FILL_BORDER_COLOR,
-  swipeSuccessThreshold: SWIPE_SUCCESS_THRESHOLD,
-  thumbIconBackgroundColor: THUMB_ICON_BACKGROUND_COLOR,
-  thumbIconBorderColor: THUMB_ICON_BORDER_COLOR,
-  thumbIconStyles: {},
-  title: "Swipe to submit",
-  titleColor: TITLE_COLOR,
-  titleFontSize: 20,
-  titleStyles: {},
 };
 
 SwipeButton.propTypes = {
@@ -209,7 +184,6 @@ SwipeButton.propTypes = {
   railFillBorderColor: PropTypes.string,
   railStyles: PropTypes.object,
   resetAfterSuccessAnimDelay: PropTypes.number,
-  resetAfterSuccessAnimDuration: PropTypes.number,
   shouldResetAfterSuccess: PropTypes.bool,
   swipeSuccessThreshold: PropTypes.number, // Ex: 70. Swipping 70% will be considered as successful swipe
   thumbIconBackgroundColor: PropTypes.string,

--- a/src/components/SwipeThumb/index.js
+++ b/src/components/SwipeThumb/index.js
@@ -17,16 +17,41 @@ import { TRANSPARENT_COLOR } from "../../constants";
 const DEFAULT_ANIMATION_DURATION = 400;
 const RESET_AFTER_SUCCESS_DEFAULT_DELAY = 1000;
 
-const SwipeThumb = (props) => {
+const SwipeThumb = ({
+  disabled = false,
+  disableResetOnTap = false,
+  disabledThumbIconBackgroundColor,
+  disabledThumbIconBorderColor,
+  enableReverseSwipe,
+  forceReset,
+  layoutWidth = 0,
+  onSwipeFail,
+  onSwipeStart,
+  onSwipeSuccess,
+  railFillBackgroundColor,
+  railFillBorderColor,
+  railStyles,
+  resetAfterSuccessAnimDelay,
+  screenReaderEnabled = false,
+  shouldResetAfterSuccess,
+  swipeSuccessThreshold,
+  thumbIconBackgroundColor,
+  thumbIconBorderColor,
+  thumbIconComponent: ThumbIconComponent,
+  thumbIconHeight,
+  thumbIconImageSource,
+  thumbIconStyles = {},
+  thumbIconWidth,
+  title,
+}) => {
   const paddingAndMarginsOffset = borderWidth + 2 * margin;
   var defaultContainerWidth = 0;
-  if (props.thumbIconWidth == undefined) {
-    defaultContainerWidth = props.thumbIconHeight;
+  if (thumbIconWidth == undefined) {
+    defaultContainerWidth = thumbIconHeight;
   } else {
-    defaultContainerWidth = props.thumbIconWidth;
+    defaultContainerWidth = thumbIconWidth;
   }
-  const forceReset = props.forceReset;
-  const maxWidth = props.layoutWidth - paddingAndMarginsOffset;
+  const maxWidth = layoutWidth - paddingAndMarginsOffset;
   const isRTL = I18nManager.isRTL;
 
   const animatedWidth = useRef(
@@ -49,7 +74,7 @@ const SwipeThumb = (props) => {
       onPanResponderMove,
       onPanResponderRelease,
     }),
-    [props],
+    [],
   );
 
   useEffect(() => {
@@ -67,7 +92,7 @@ const SwipeThumb = (props) => {
   function onSwipeNotMetSuccessThreshold() {
     // Animate to initial position
     setDefaultWidth(defaultContainerWidth);
-    props.onSwipeFail && props.onSwipeFail();
+    onSwipeFail && onSwipeFail();
   }
 
   function onSwipeMetSuccessThreshold(newWidth) {
@@ -80,17 +105,17 @@ const SwipeThumb = (props) => {
   }
 
   function onPanResponderStart() {
-    if (props.disabled) {
+    if (disabled) {
       return;
     }
-    props.onSwipeStart && props.onSwipeStart();
+    onSwipeStart && onSwipeStart();
   }
 
-  async function onPanResponderMove(event, gestureState) {
-    if (props.disabled) {
+  async function onPanResponderMove(_, gestureState) {
+    if (disabled) {
       return;
     }
-    const reverseMultiplier = props.enableReverseSwipe ? -1 : 1;
+    const reverseMultiplier = enableReverseSwipe ? -1 : 1;
     const rtlMultiplier = isRTL ? -1 : 1;
     const newWidth =
       defaultContainerWidth +
@@ -113,24 +138,22 @@ const SwipeThumb = (props) => {
     }
   }
 
-  function onPanResponderRelease(event, gestureState) {
-    if (props.disabled) {
+  function onPanResponderRelease(_, gestureState) {
+    if (disabled) {
       return;
     }
-    const reverseMultiplier = props.enableReverseSwipe ? -1 : 1;
+    const reverseMultiplier = enableReverseSwipe ? -1 : 1;
     const rtlMultiplier = isRTL ? -1 : 1;
     const newWidth =
       defaultContainerWidth +
       rtlMultiplier * reverseMultiplier * gestureState.dx;
-    const successThresholdWidth =
-      maxWidth * (props.swipeSuccessThreshold / 100);
+    const successThresholdWidth = maxWidth * (swipeSuccessThreshold / 100);
     newWidth < successThresholdWidth
       ? onSwipeNotMetSuccessThreshold()
       : onSwipeMetSuccessThreshold(newWidth);
   }
 
   function setBackgroundColors() {
-    const { railFillBackgroundColor, railFillBorderColor } = props;
     // Set backgroundColor only if not already set
     if (backgroundColor === TRANSPARENT_COLOR) {
       setBackgroundColor(railFillBackgroundColor);
@@ -146,17 +169,17 @@ const SwipeThumb = (props) => {
     //Animate back to initial position after successfully swiped
     const resetDelay =
       DEFAULT_ANIMATION_DURATION +
-      (props.resetAfterSuccessAnimDelay !== undefined
-        ? props.resetAfterSuccessAnimDelay
+      (resetAfterSuccessAnimDelay !== undefined
+        ? resetAfterSuccessAnimDelay
         : RESET_AFTER_SUCCESS_DEFAULT_DELAY);
     setTimeout(() => {
-      props.shouldResetAfterSuccess && reset();
+      shouldResetAfterSuccess && reset();
     }, resetDelay);
   }
 
   function invokeOnSwipeSuccess() {
-    disableTouch(props.disableResetOnTap);
-    props.onSwipeSuccess && props.onSwipeSuccess();
+    disableTouch(disableResetOnTap);
+    onSwipeSuccess && onSwipeSuccess();
   }
 
   function reset() {
@@ -170,18 +193,6 @@ const SwipeThumb = (props) => {
   }
 
   function renderThumbIcon() {
-    const {
-      disabled,
-      disabledThumbIconBackgroundColor,
-      disabledThumbIconBorderColor,
-      thumbIconBackgroundColor,
-      thumbIconBorderColor,
-      thumbIconComponent: ThumbIconComponent,
-      thumbIconHeight,
-      thumbIconImageSource,
-      thumbIconStyles,
-      thumbIconWidth,
-    } = props;
     var iconWidth = 0;
     if (thumbIconWidth == undefined) {
       iconWidth = thumbIconHeight;
@@ -214,15 +225,6 @@ const SwipeThumb = (props) => {
       </View>
     );
   }
-
-  const {
-    disabled,
-    enableReverseSwipe,
-    onSwipeSuccess,
-    railStyles,
-    screenReaderEnabled,
-    title,
-  } = props;
 
   const panStyle = {
     backgroundColor,
@@ -260,15 +262,6 @@ const SwipeThumb = (props) => {
   );
 };
 
-SwipeThumb.defaultProps = {
-  disabled: false,
-  layoutWidth: 0,
-  resetAfterSuccessAnimDuration: 200,
-  disableResetOnTap: false,
-  screenReaderEnabled: false,
-  thumbIconStyles: {},
-};
-
 SwipeThumb.propTypes = {
   disabled: PropTypes.bool,
   disableResetOnTap: PropTypes.bool,
@@ -283,7 +276,7 @@ SwipeThumb.propTypes = {
   railFillBackgroundColor: PropTypes.string,
   railFillBorderColor: PropTypes.string,
   railStyles: PropTypes.object,
-  resetAfterSuccessAnimDuration: PropTypes.number,
+  resetAfterSuccessAnimDelay: PropTypes.number,
   screenReaderEnabled: PropTypes.bool,
   shouldResetAfterSuccess: PropTypes.bool,
   swipeSuccessThreshold: PropTypes.number,


### PR DESCRIPTION
- Replaced all default props with javascript default params.
- Removed an unused property resetAfterSuccessAnimDuration.


Tested it locally on the Android emulator. No issues found.

[Screen_recording_20241107_234803.webm](https://github.com/user-attachments/assets/af5f94fb-476c-435c-8136-655dfecdc967)
