### PR TITLE
Allow overriding the internal screenReaerEnabled value

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ import SwipeButton from 'rn-swipe-button';
 </div>
 <hr>
 
+<h2 style="color:darkgreen;">Web Demo</h2>
+<video src="https://github.com/UdaySravanK/RNSwipeButtonDemo/blob/main/assets/images/rn-swipe-button-web.mov" />
+
 <h2 style="color:darkgreen;">Component properties</h2>
 <pre style="font-size: 15px; color: brown;">
     <b>containerStyles</b>: PropTypes.object,
@@ -90,7 +93,7 @@ import SwipeButton from 'rn-swipe-button';
     <b>railFillBorderColor</b>: PropTypes.string,
     <b>railStyles</b>: PropTypes.object,
     <b>resetAfterSuccessAnimDelay</b>: PropTypes.number, <span style="color: blueviolet">// This is delay before resetting the button after successful swipe When shouldResetAfterSuccess = true </span>
-    <b>screenReaderEnabled</b>: PropTypes.bool,
+    <b>screenReaderEnabled</b>: PropTypes.bool, <span style="color: blueviolet">// Overrides the internal value </span>
     <b>shouldResetAfterSuccess</b>: PropTypes.bool, <span style="color: blueviolet">// If set to true, buttun resets automatically after swipe success with default delay of 1000ms</span>
     <b>swipeSuccessThreshold</b>: PropTypes.number, <span style="color: blueviolet">// Ex: 70. Swipping 70% will be considered as successful swipe</span>
     <b>thumbIconBackgroundColor</b>: PropTypes.string,

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ import SwipeButton from 'rn-swipe-button';
 <hr>
 
 <h2 style="color:darkgreen;">Web Demo</h2>
-<video src="https://github.com/UdaySravanK/RNSwipeButtonDemo/blob/main/assets/images/rn-swipe-button-web.mov" />
+<img src="https://github.com/UdaySravanK/RNSwipeButtonDemo/blob/main/assets/images/rn-swipe-button-web.gif" style="margin-right: 30px;" width="400"/>
+
 
 <h2 style="color:darkgreen;">Component properties</h2>
 <pre style="font-size: 15px; color: brown;">

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@
 
 <hr>
 
+
+## Description
+- Highly customizable "swipe to submit" category button. 
+- Generally used in exchange of regular buttons to avoid accidental taps.
+- This component works for Android, iOS and Web application.
+- Supports RTL out of the box.
+- Provides accessiblity support.
+- Component has more than 85% test coverge.
+- 100% TypeScript
+- MIT License
+
+
 ## Installation 
 
 ```bash
@@ -66,7 +78,9 @@ import SwipeButton from 'rn-swipe-button';
 <hr>
 
 <h2 style="color:darkgreen;">Web Demo</h2>
-<img src="https://github.com/UdaySravanK/RNSwipeButtonDemo/blob/main/assets/images/rn-swipe-button-web.gif" style="margin-right: 30px;" width="400"/>
+<p align="center">
+  <img src="https://github.com/UdaySravanK/RNSwipeButtonDemo/blob/main/assets/images/rn-swipe-button-web.gif" width="400"/>
+</p>
 
 
 <h2 style="color:darkgreen;">Component properties</h2>

--- a/src/components/SwipeButton/__tests__/SwipeButton.test.tsx
+++ b/src/components/SwipeButton/__tests__/SwipeButton.test.tsx
@@ -163,4 +163,24 @@ describe("Component: SwipeButton UI Rendering Tree & Props", () => {
     // Assert
     expect(screen.toJSON()).toMatchSnapshot();
   });
+
+  it("should render correctly with screen reader enabled", async () => {
+    // Setup
+    render(<SwipeButton screenReaderEnabled />);
+    const button = screen.getAllByTestId("SwipeButton")[0];
+    fireEvent(button, "onLayout", { nativeEvent: { layout: { width: 100 } } });
+
+    // Assert
+    expect(screen.toJSON()).toMatchSnapshot();
+  });
+
+  it("should render correctly with screen reader disabled", async () => {
+    // Setup
+    render(<SwipeButton screenReaderEnabled={false} />);
+    const button = screen.getAllByTestId("SwipeButton")[0];
+    fireEvent(button, "onLayout", { nativeEvent: { layout: { width: 100 } } });
+
+    // Assert
+    expect(screen.toJSON()).toMatchSnapshot();
+  });
 });

--- a/src/components/SwipeButton/__tests__/__snapshots__/SwipeButton.test.tsx.snap
+++ b/src/components/SwipeButton/__tests__/__snapshots__/SwipeButton.test.tsx.snap
@@ -1194,6 +1194,244 @@ exports[`Component: SwipeButton UI Rendering Tree & Props should render correctl
 </View>
 `;
 
+exports[`Component: SwipeButton UI Rendering Tree & Props should render correctly with screen reader disabled 1`] = `
+<View
+  accessibilityHint="Swipe to submit"
+  accessibilityLabel="Swipe to submit"
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": false,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onLayout={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "backgroundColor": "#7CF3F9",
+      "borderColor": "#073436",
+      "borderRadius": 50,
+      "borderWidth": 1,
+      "justifyContent": "center",
+      "margin": 5,
+      "opacity": 1,
+    }
+  }
+  testID="SwipeButton"
+>
+  <Text
+    ellipsizeMode="tail"
+    numberOfLines={1}
+    style={
+      [
+        {
+          "alignSelf": "center",
+          "position": "absolute",
+        },
+        {
+          "color": "#083133",
+          "fontSize": 20,
+        },
+      ]
+    }
+  >
+    Swipe to submit
+  </Text>
+  <View
+    collapsable={false}
+    onMoveShouldSetResponder={[Function]}
+    onMoveShouldSetResponderCapture={[Function]}
+    onResponderEnd={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderReject={[Function]}
+    onResponderRelease={[Function]}
+    onResponderStart={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    onStartShouldSetResponderCapture={[Function]}
+    pointerEvents="auto"
+    style={
+      {
+        "alignItems": "flex-end",
+        "alignSelf": "flex-start",
+        "backgroundColor": "#00000000",
+        "borderColor": "#00000000",
+        "borderRadius": 50,
+        "borderRightWidth": 0,
+        "borderWidth": 3,
+        "margin": 1,
+        "width": 50,
+      }
+    }
+    testID="SwipeThumb"
+  >
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "borderRadius": 50,
+            "borderWidth": 2,
+            "justifyContent": "center",
+            "marginVertical": -3,
+          },
+          {
+            "backgroundColor": "#D27030",
+            "borderColor": "#3D797C",
+            "height": 50,
+            "overflow": "hidden",
+            "width": 50,
+          },
+        ]
+      }
+      testID="DefaultThumbIcon"
+    />
+  </View>
+</View>
+`;
+
+exports[`Component: SwipeButton UI Rendering Tree & Props should render correctly with screen reader enabled 1`] = `
+<View
+  accessibilityHint="Double tap to activate"
+  accessibilityLabel="Swipe to submit"
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": false,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onLayout={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "backgroundColor": "#7CF3F9",
+      "borderColor": "#073436",
+      "borderRadius": 50,
+      "borderWidth": 1,
+      "justifyContent": "center",
+      "margin": 5,
+      "opacity": 1,
+    }
+  }
+  testID="SwipeButton"
+>
+  <Text
+    ellipsizeMode="tail"
+    numberOfLines={1}
+    style={
+      [
+        {
+          "alignSelf": "center",
+          "position": "absolute",
+        },
+        {
+          "color": "#083133",
+          "fontSize": 20,
+        },
+      ]
+    }
+  >
+    Swipe to submit
+  </Text>
+  <View
+    collapsable={false}
+    onMoveShouldSetResponder={[Function]}
+    onMoveShouldSetResponderCapture={[Function]}
+    onResponderEnd={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderReject={[Function]}
+    onResponderRelease={[Function]}
+    onResponderStart={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    onStartShouldSetResponderCapture={[Function]}
+    pointerEvents="auto"
+    style={
+      {
+        "alignItems": "flex-end",
+        "alignSelf": "flex-start",
+        "backgroundColor": "#00000000",
+        "borderColor": "#00000000",
+        "borderRadius": 50,
+        "borderRightWidth": 0,
+        "borderWidth": 3,
+        "margin": 1,
+        "width": 50,
+      }
+    }
+    testID="SwipeThumb"
+  >
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "borderRadius": 50,
+            "borderWidth": 2,
+            "justifyContent": "center",
+            "marginVertical": -3,
+          },
+          {
+            "backgroundColor": "#D27030",
+            "borderColor": "#3D797C",
+            "height": 50,
+            "overflow": "hidden",
+            "width": 50,
+          },
+        ]
+      }
+      testID="DefaultThumbIcon"
+    />
+  </View>
+</View>
+`;
+
 exports[`Component: SwipeButton UI Rendering Tree & Props should render with correct styles when disable 1`] = `
 <View
   accessibilityHint="Button disabled"

--- a/src/components/SwipeButton/index.tsx
+++ b/src/components/SwipeButton/index.tsx
@@ -257,7 +257,6 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
           railFillBorderColor={railFillBorderColor}
           railStyles={railStyles}
           resetAfterSuccessAnimDelay={resetAfterSuccessAnimDelay}
-          screenReaderEnabled={screenReaderEnabled}
           shouldResetAfterSuccess={shouldResetAfterSuccess}
           swipeSuccessThreshold={swipeSuccessThreshold}
           thumbIconBackgroundColor={thumbIconBackgroundColor}

--- a/src/components/SwipeButton/index.tsx
+++ b/src/components/SwipeButton/index.tsx
@@ -57,6 +57,7 @@ interface SwipeButtonProps extends TouchableOpacityProps {
   railFillBorderColor?: string;
   railStyles?: ViewStyle;
   resetAfterSuccessAnimDelay?: number;
+  screenReaderEnabled?: boolean;
   shouldResetAfterSuccess?: boolean;
   swipeSuccessThreshold?: number;
   thumbIconBackgroundColor?: string;
@@ -101,6 +102,7 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
   railFillBorderColor = RAIL_FILL_BORDER_COLOR,
   railStyles,
   resetAfterSuccessAnimDelay,
+  screenReaderEnabled,
   shouldResetAfterSuccess,
   swipeSuccessThreshold = SWIPE_SUCCESS_THRESHOLD,
   thumbIconBackgroundColor = THUMB_ICON_BACKGROUND_COLOR,
@@ -119,7 +121,8 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
   ...rest // Include other TouchableOpacity props
 }) => {
   const [layoutWidth, setLayoutWidth] = useState(0);
-  const [screenReaderEnabled, setScreenReaderEnabled] = useState(false);
+  const [isScreenReaderEnabled, setScreenReaderEnabled] =
+    useState(screenReaderEnabled);
   const [isUnmounting, setIsUnmounting] = useState(false);
   const [activationMessage, setActivationMessage] = useState(title);
   const [disableInteraction, setDisableInteraction] = useState(false);
@@ -144,19 +147,28 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
    * Which results to all interactions disabled. Swipe gesture won't work.
    */
   useEffect(() => {
-    if (disabled && screenReaderEnabled) {
+    if (disabled && isScreenReaderEnabled) {
       setDisableInteraction(true);
     } else {
       setDisableInteraction(false);
     }
-  }, [disabled, screenReaderEnabled]);
+  }, [disabled, isScreenReaderEnabled]);
 
-  const handleScreenReaderToggled = (isEnabled: boolean) => {
-    if (isUnmounting || screenReaderEnabled === isEnabled) {
-      return;
-    }
-    setScreenReaderEnabled(isEnabled);
-  };
+  const handleScreenReaderToggled = useCallback(
+    (isEnabled: boolean) => {
+      if (isUnmounting || isScreenReaderEnabled === isEnabled) {
+        return;
+      }
+      if (screenReaderEnabled !== undefined) {
+        setScreenReaderEnabled(screenReaderEnabled);
+        // Return to avoid overriding the externally set value
+        return;
+      }
+
+      setScreenReaderEnabled(isEnabled);
+    },
+    [isScreenReaderEnabled, screenReaderEnabled],
+  );
 
   useEffect(() => {
     setIsUnmounting(false);
@@ -173,28 +185,30 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
         subscription.remove();
       }
     };
-  }, [setIsUnmounting, screenReaderEnabled, handleScreenReaderToggled]);
+  }, [isScreenReaderEnabled, handleScreenReaderToggled]);
 
   useEffect(() => {
     // Update activation message based on disabled state and screen reader status
     if (disabled) {
       setActivationMessage("Button disabled");
-    } else if (screenReaderEnabled) {
+    } else if (isScreenReaderEnabled) {
       setActivationMessage("Double tap to activate");
     } else {
       setActivationMessage(title);
     }
-  }, [disabled, screenReaderEnabled]);
+  }, [disabled, isScreenReaderEnabled]);
 
   const handlePress = useCallback(() => {
     if (disabled) return;
-    if (screenReaderEnabled) {
+    if (isScreenReaderEnabled) {
       // Simulate swipe success for screen readers
       onSwipeSuccess && onSwipeSuccess(false);
     }
-  }, [disabled, screenReaderEnabled, onSwipeSuccess]);
+  }, [disabled, isScreenReaderEnabled, onSwipeSuccess]);
 
   const handleFocus = useCallback(() => {
+    debugger;
+    console.log("handle focus called");
     AccessibilityInfo.isScreenReaderEnabled().then(handleScreenReaderToggled);
   }, [handleScreenReaderToggled]);
 

--- a/src/components/SwipeButton/index.tsx
+++ b/src/components/SwipeButton/index.tsx
@@ -207,8 +207,6 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
   }, [disabled, isScreenReaderEnabled, onSwipeSuccess]);
 
   const handleFocus = useCallback(() => {
-    debugger;
-    console.log("handle focus called");
     AccessibilityInfo.isScreenReaderEnabled().then(handleScreenReaderToggled);
   }, [handleScreenReaderToggled]);
 

--- a/src/components/SwipeButton/index.tsx
+++ b/src/components/SwipeButton/index.tsx
@@ -121,7 +121,7 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
   ...rest // Include other TouchableOpacity props
 }) => {
   const [layoutWidth, setLayoutWidth] = useState(0);
-  const [isScreenReaderEnabled, setScreenReaderEnabled] =
+  const [isScreenReaderEnabled, setIsScreenReaderEnabled] =
     useState(screenReaderEnabled);
   const [isUnmounting, setIsUnmounting] = useState(false);
   const [activationMessage, setActivationMessage] = useState(title);
@@ -160,12 +160,12 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
         return;
       }
       if (screenReaderEnabled !== undefined) {
-        setScreenReaderEnabled(screenReaderEnabled);
+        setIsScreenReaderEnabled(screenReaderEnabled);
         // Return to avoid overriding the externally set value
         return;
       }
 
-      setScreenReaderEnabled(isEnabled);
+      setIsScreenReaderEnabled(isEnabled);
     },
     [isScreenReaderEnabled, screenReaderEnabled],
   );

--- a/src/components/SwipeThumb/index.tsx
+++ b/src/components/SwipeThumb/index.tsx
@@ -46,7 +46,6 @@ interface SwipeThumbProps {
   railFillBorderColor?: string;
   railStyles?: ViewStyle;
   resetAfterSuccessAnimDelay?: number;
-  screenReaderEnabled?: boolean;
   shouldResetAfterSuccess?: boolean;
   swipeSuccessThreshold?: number;
   thumbIconBackgroundColor?: string;
@@ -76,7 +75,6 @@ const SwipeThumb: React.FC<SwipeThumbProps> = React.memo((props) => {
     railFillBorderColor,
     railStyles,
     resetAfterSuccessAnimDelay,
-    screenReaderEnabled = false,
     shouldResetAfterSuccess,
     swipeSuccessThreshold,
     thumbIconBackgroundColor,
@@ -147,7 +145,7 @@ const SwipeThumb: React.FC<SwipeThumbProps> = React.memo((props) => {
 
   const onPanResponderMove = useCallback(
     async (_: any, gestureState: PanResponderGestureState) => {
-      if (disabled || screenReaderEnabled) return;
+      if (disabled) return;
 
       const reverseMultiplier = enableReverseSwipe ? -1 : 1;
       const rtlMultiplier = isRTL ? -1 : 1;
@@ -172,7 +170,6 @@ const SwipeThumb: React.FC<SwipeThumbProps> = React.memo((props) => {
     },
     [
       disabled,
-      screenReaderEnabled,
       defaultContainerWidth,
       maxWidth,
       isRTL,

--- a/types.d.ts
+++ b/types.d.ts
@@ -52,6 +52,10 @@ interface Props {
      * The button can be reset to original state upon a succesful swipe by setting `shouldResetAfterSuccess` to true. This prop is to set the delay.
      */
     resetAfterSuccessAnimDelay?: number;
+    /**
+     * Detecting screen reader enabled is not very reliable across platforms. So, exposing it to override the internal value.
+     */
+    screenReaderEnabled?: boolean; 
     shouldResetAfterSuccess?: boolean;
     /**
      * If you set it to 50, it means after swiping 50%, the remaining will be auto completed.


### PR DESCRIPTION
- screenReaderEnabled value is always setting to true when running the web app. This is breaking the swipe functionality. Removed the 'disable swipe move' gesture when a11y enabled.
- Detecting the screen reader status across platforms is inconsistent and unreliable. So, exposing this value to give control to higher level components. 
- Add more test case

## Assets
Web Demo
<img width="400" src="https://github.com/user-attachments/assets/12701e92-e41e-4204-ae1a-0776da7c9e38" />

## Test Coverage change

### Before
<img width="768" src="https://github.com/user-attachments/assets/bd274d10-cd95-4846-96e4-24aa4eb8d5da" />

### After
<img width="768"  src="https://github.com/user-attachments/assets/4173bdda-215a-4eb7-a7e3-278f18320e53" />
