### PR TITLE
Added the ability to use a component for the title field same as thum…

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ import SwipeButton from 'rn-swipe-button';
     ]),
     <b>thumbIconStyles</b>: PropTypes.object,
     <b>thumbIconWidth</b>: PropTypes.number,
+    <b>titleComponent</b>: PropTypes.node, <span style="color: blueviolet">Pass any react component to replace title text element</span>
     <b>title</b>: PropTypes.string,
     <b>titleColor</b>: PropTypes.string,
     <b>titleFontSize</b>: PropTypes.number,

--- a/src/components/SwipeButton/index.tsx
+++ b/src/components/SwipeButton/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, ReactElement, useCallback } from "react";
 import {
+  View,
   Text,
   AccessibilityInfo,
   TouchableOpacity,
@@ -66,6 +67,7 @@ interface SwipeButtonProps extends TouchableOpacityProps {
   thumbIconImageSource?: ImageSourcePropType;
   thumbIconStyles?: ViewStyle;
   thumbIconWidth?: number;
+  titleComponent?: () => ReactElement;
   title?: string;
   titleColor?: string;
   titleFontSize?: number;
@@ -111,6 +113,7 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
   thumbIconImageSource,
   thumbIconStyles = {},
   thumbIconWidth,
+  titleComponent: TitleComponent,
   title = DEFAULT_TITLE,
   titleColor = TITLE_COLOR,
   titleFontSize = DEFAULT_TITLE_FONT_SIZE,
@@ -234,21 +237,27 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
       testID="SwipeButton"
       {...rest}
     >
-      <Text
-        maxFontSizeMultiplier={titleMaxFontScale}
-        ellipsizeMode={"tail"}
-        numberOfLines={titleMaxLines}
-        style={[
-          styles.title,
-          {
-            color: titleColor,
-            fontSize: titleFontSize,
-            ...titleStyles,
-          },
-        ]}
-      >
-        {title}
-      </Text>
+      {TitleComponent ? (
+          <View style={{...styles.title}}>
+            <TitleComponent />
+          </View>
+      ) : (
+          <Text
+              maxFontSizeMultiplier={titleMaxFontScale}
+              ellipsizeMode={"tail"}
+              numberOfLines={titleMaxLines}
+              style={[
+                styles.title,
+                {
+                  color: titleColor,
+                  fontSize: titleFontSize,
+                  ...titleStyles,
+                },
+              ]}
+          >
+            {title}
+          </Text>
+      )}
       {layoutWidth > 0 && (
         <SwipeThumb
           disabled={disabled}

--- a/types.d.ts
+++ b/types.d.ts
@@ -31,7 +31,7 @@ interface Props {
      */
     forceReset?: (forceReset: () => void) => void;
     /**
-     * This is the height of thumb which we interact to swipe. 
+     * This is the height of thumb which we interact to swipe.
      * The width of the thumb will be automatically set to the height by default. But the thumb can be costomized with `thumbIconComponent`.
      * Default value is 50
      */
@@ -55,11 +55,11 @@ interface Props {
     /**
      * Detecting screen reader enabled is not very reliable across platforms. So, exposing it to override the internal value.
      */
-    screenReaderEnabled?: boolean; 
+    screenReaderEnabled?: boolean;
     shouldResetAfterSuccess?: boolean;
     /**
      * If you set it to 50, it means after swiping 50%, the remaining will be auto completed.
-     * 
+     *
      * Default value is 70.
      */
     swipeSuccessThreshold?: number;
@@ -70,6 +70,7 @@ interface Props {
     thumbIconStyles?: StyleProp<ViewStyle>;
     thumbIconHeight?: number;
     thumbIconWidth?: number;
+    titleComponent?: () => ReactElement;
     title?: string;
     titleColor?: string;
     /**


### PR DESCRIPTION
Added titleComponent as prop type, defined in types.d.ts, explained in README.md and applied to main component so we can replace the title component with a custom component such as animated icons or maybe just custom text component.